### PR TITLE
fix: remove mocks

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,12 +26,7 @@ const mocks = {
 };
 
 async function startApolloServer() {
-  const server = new ApolloServer({
-    schema: addMocksToSchema({
-      schema: makeExecutableSchema({ typeDefs }),
-      mocks,
-    }),
-  });
+  const server = new ApolloServer({ typeDefs });
   const { url } = await startStandaloneServer(server);
   console.log(`
     🚀  Server is running!


### PR DESCRIPTION
[Lift-off II: Resolvers - Querying live data](https://www.apollographql.com/tutorials/lift-off-part2/08-querying-live-data) <br>
Hi, I was getting mocked responses event after switching it OFF in the gear menu. It only stopped when I replaced
```
{
    schema: addMocksToSchema({
      schema: makeExecutableSchema({ typeDefs, resolvers }),
    }),
  }
```
with `{ typeDefs, resolvers }`. I would suggest replacing it in the repo itself since both the code in the video doesn't have mocks and mocks aren't used in lift-off 2.